### PR TITLE
Environment: Dev Container のコンテナーをカスタマイズできるようにする

### DIFF
--- a/.devcontainer/.gitignore
+++ b/.devcontainer/.gitignore
@@ -1,0 +1,1 @@
+/post_create_custom.sh

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -18,6 +18,7 @@ IFS=$'\n\t'
 WORKSPACE_PATH=/workspaces
 BACKEND_PACKAGE_PATH="${WORKSPACE_PATH}/backend"
 FRONTEND_PACKAGE_PATH="${WORKSPACE_PATH}/frontend"
+CUSTOM_POST_CREATE_SCRIPT_PATH="${WORKSPACE_PATH}/.devcontainer/post_create_custom.sh"
 
 # 各パッケージの package.json を参照して pnpm と依存関係をインストールする
 echo "Install backend dependencies..."
@@ -27,3 +28,9 @@ corepack pnpm install --frozen-lockfile
 echo "Install frontend dependencies..."
 cd "$FRONTEND_PACKAGE_PATH"
 corepack pnpm install --frozen-lockfile
+
+# Run custom post create script
+if [ -f "$CUSTOM_POST_CREATE_SCRIPT_PATH" ]; then
+  echo "Run custom post create script ($CUSTOM_POST_CREATE_SCRIPT_PATH)..."
+  eval "$CUSTOM_POST_CREATE_SCRIPT_PATH"
+fi

--- a/.devcontainer/post_create_custom.sh.example
+++ b/.devcontainer/post_create_custom.sh.example
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Bash Strict Mode (http://redsymbol.net/articles/unofficial-bash-strict-mode/)
+set -euo pipefail
+IFS=$'\n\t'
+
+# Install Vim
+sudo apt-get install vim --yes
+
+# [README]
+# Dev Containerのコンテナー作成後にお好きな処理 (お気に入りのエディターのインストールなど)をコンテナーで実行させたい場合は
+# このファイルと同じディレクトリーに post_create_custom.sh という名前のファイルを作り
+# このファイルのようにシェルスクリプトを記述してください。
+#
+# 実行権を付与 (chmod +x)する必要があることに注意してください。(このファイルをコピーするとよいでしょう)


### PR DESCRIPTION
## Why
Vimmerなの（現状 `vim` はおろか `nano` すら入ってなくて辛い）

## What
実行権付きの `/.devcontainer/post_create_custom.sh` ファイルが存在する場合\
コンテナー作成後にそのシェルスクリプトが実行されるようにする。

### Changes
- **Environment**: Devcontainer のコンテナー生成時にカスタムスクリプトを実行する
