### PR TITLE
Chore: FrontEndのLazy Routeを修正

### DIFF
--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -24,7 +24,7 @@ const LoginRouteRoute = LoginRouteImport.update({
 const RouteRoute = RouteImport.update({
   path: '/',
   getParentRoute: () => rootRoute,
-} as any)
+} as any).lazy(() => import('./routes/route.lazy').then((d) => d.Route))
 
 // Populate the FileRoutesByPath interface
 

--- a/frontend/src/routes/login/route.lazy.tsx
+++ b/frontend/src/routes/login/route.lazy.tsx
@@ -1,7 +1,17 @@
-import { createLazyFileRoute } from "@tanstack/react-router";
-
-import { Login } from "./route";
+import { Button } from "@mantine/core";
+import { createLazyFileRoute, Link } from "@tanstack/react-router";
 
 export const Route = createLazyFileRoute("/login")({
   component: Login,
 });
+
+export function Login() {
+  return (
+    <>
+      <p>Login Page</p>
+      <Link to="/">
+        <Button>Top</Button>
+      </Link>
+    </>
+  );
+}

--- a/frontend/src/routes/login/route.tsx
+++ b/frontend/src/routes/login/route.tsx
@@ -1,10 +1,8 @@
-import { Button } from "@mantine/core";
-import { Link, createFileRoute } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 
 import { BACKEND_EJS_VARIABLE_KEYS } from "@/staticDataRouteOption";
 
 export const Route = createFileRoute("/login")({
-  component: Login,
   staticData: {
     openGraph: {
       title: `<%= ${BACKEND_EJS_VARIABLE_KEYS.siteName} + ' | Login' %>`,
@@ -13,14 +11,3 @@ export const Route = createFileRoute("/login")({
     },
   },
 });
-
-export function Login() {
-  return (
-    <>
-      <p>Login Page</p>
-      <Link to="/">
-        <Button>Top</Button>
-      </Link>
-    </>
-  );
-}

--- a/frontend/src/routes/route.lazy.tsx
+++ b/frontend/src/routes/route.lazy.tsx
@@ -1,0 +1,21 @@
+import { Button, Group } from "@mantine/core";
+import { createLazyFileRoute, Link } from "@tanstack/react-router";
+
+import { DeleteParrot } from "./-components/DeleteParrot";
+
+export const Route = createLazyFileRoute("/")({
+  component: Home,
+});
+
+function Home() {
+  return (
+    <>
+      <DeleteParrot />
+      <Group justify="center" mt="lg">
+        <Button component={Link} to="/login">
+          LOGIN
+        </Button>
+      </Group>
+    </>
+  );
+}

--- a/frontend/src/routes/route.tsx
+++ b/frontend/src/routes/route.tsx
@@ -1,12 +1,8 @@
-import { Button, Group } from "@mantine/core";
-import { Link, createFileRoute } from "@tanstack/react-router";
-
-import { DeleteParrot } from "./-components/DeleteParrot";
+import { createFileRoute } from "@tanstack/react-router";
 
 import { BACKEND_EJS_VARIABLE_KEYS } from "@/staticDataRouteOption";
 
 export const Route = createFileRoute("/")({
-  component: Home,
   staticData: {
     openGraph: {
       title: `<%= ${BACKEND_EJS_VARIABLE_KEYS.siteName} %>`,
@@ -15,16 +11,3 @@ export const Route = createFileRoute("/")({
     },
   },
 });
-
-function Home() {
-  return (
-    <>
-      <DeleteParrot />
-      <Group justify="center" mt="lg">
-        <Button component={Link} to="/login">
-          LOGIN
-        </Button>
-      </Group>
-    </>
-  );
-}


### PR DESCRIPTION
- 同じルートで、LazyFileRouteに生えてないやつは通常のFileRoute、それ以外はLazyFileRouteみたいに分けれることが判明したので修正
  - https://tanstack.com/router/latest/docs/framework/react/guide/code-splitting#example-code-splitting-with-lazytsx